### PR TITLE
Use LCS to compare iterables

### DIFF
--- a/dast/__main__.py
+++ b/dast/__main__.py
@@ -15,7 +15,7 @@ import ast
 import sys
 from functools import partial
 
-from deepdiff import DeepDiff
+from dast.diff import Diff
 
 from dast.from_ast import strip, prettify
 
@@ -37,7 +37,7 @@ def main(then_path: str, now_path: str, verbose: bool = True):
         strip(now_ast)
         prettify(now_ast)
 
-    diff = DeepDiff(then_ast, now_ast)
+    diff = Diff(then_ast, now_ast)
     if diff and verbose:
         print(f"diff for file {now_path}")
         print(diff)

--- a/dast/diff.py
+++ b/dast/diff.py
@@ -21,7 +21,7 @@ class Diff(DeepDiff):
         t2_hashes = DeepHash(level.t2)
         t2 = [t2_hashes[level.t2[i]] for i in range(len(level.t2))]
 
-        lcs, t1_in_lcs, t2_in_lcs = get_lcs(t1, t2)
+        lcs = get_lcs(t1, t2)
 
         pairs = []
 

--- a/dast/diff.py
+++ b/dast/diff.py
@@ -42,7 +42,7 @@ class Diff(DeepDiff):
             try:
                 if t1[i] != lcs[n]:
                     pairs.append((
-                        (i, -1), (t1[i], ListItemRemovedOrAdded)
+                        (i, -1), (level.t1[i], ListItemRemovedOrAdded)
                     ))
                     i += 1
             except IndexError:
@@ -50,7 +50,7 @@ class Diff(DeepDiff):
             try:
                 if t2[j] != lcs[n]:
                     pairs.append((
-                        (-1, j), (ListItemRemovedOrAdded, t2[j])
+                        (-1, j), (ListItemRemovedOrAdded, level.t2[j])
                     ))
                     j += 1
             except IndexError:

--- a/dast/diff.py
+++ b/dast/diff.py
@@ -17,9 +17,9 @@ class Diff(DeepDiff):
         Will compute the LCS between the two levels by using the DistanceMixin and a maximum cutoff threshold
         """
         t1_hashes = DeepHash(level.t1)
-        t1 = [t1_hashes[level.t1[i]] for i in range(len(level.t1))]
+        t1 = [t1_hashes[obj] for obj in level.t1]
         t2_hashes = DeepHash(level.t2)
-        t2 = [t2_hashes[level.t2[i]] for i in range(len(level.t2))]
+        t2 = [t2_hashes[obj] for obj in level.t2]
 
         lcs = get_lcs(t1, t2)
 

--- a/dast/diff.py
+++ b/dast/diff.py
@@ -1,0 +1,58 @@
+"""
+The main logic for the diff as it differs from DeepDiff
+"""
+from deepdiff import DeepDiff, DeepHash
+from deepdiff.diff import ListItemRemovedOrAdded, DiffLevel
+
+from dast.lcs import get_lcs
+
+class Diff(DeepDiff):
+    def _get_matching_pairs(self, level):
+        """
+        Given a level get matching pairs. This returns list of two tuples in the form:
+        [
+          (t1 index, t2 index), (t1 item, t2 item)
+        ]
+
+        Will compute the LCS between the two levels by using the DistanceMixin and a maximum cutoff threshold
+        """
+        t1_hashes = DeepHash(level.t1)
+        t1 = [t1_hashes[level.t1[i]] for i in range(len(level.t1))]
+        t2_hashes = DeepHash(level.t2)
+        t2 = [t2_hashes[level.t2[i]] for i in range(len(level.t2))]
+
+        lcs, t1_in_lcs, t2_in_lcs = get_lcs(t1, t2)
+
+        pairs = []
+
+        i = 0
+        j = 0
+        n = 0
+        while any([n < len(lcs), i < len(t1), j < len(t2)]):
+            try:
+                if t1[i] == t2[j] == lcs[n]:
+                    pairs.append((
+                        (i, j), (level.t1[i], level.t2[j])
+                    ))
+                    i += 1
+                    j += 1
+                    n += 1
+            except IndexError:
+                pass
+            try:
+                if t1[i] != lcs[n]:
+                    pairs.append((
+                        (i, -1), (t1[i], ListItemRemovedOrAdded)
+                    ))
+                    i += 1
+            except IndexError:
+                pass
+            try:
+                if t2[j] != lcs[n]:
+                    pairs.append((
+                        (-1, j), (ListItemRemovedOrAdded, t2[j])
+                    ))
+                    j += 1
+            except IndexError:
+                pass
+        return pairs


### PR DESCRIPTION
This allows us to detect items removed and added that are not at the end of the iterable.

It's not very pretty at the moment and it doesn't handle changes in nested structures. For example:

```
if True:
    a = 5
    b = 5
```
to 
```
if True:
    a = 5
    c = 5
    b = 5
```
Will just show as one `if` added and one removed. In order to make them compare within we'll have to make the pairs match. `DeepDiff` provides a distance function which I think we may be able to use

