### PR TITLE
Don't strip AST, ignore irrelevant props in the diff

### DIFF
--- a/dast/__main__.py
+++ b/dast/__main__.py
@@ -17,7 +17,7 @@ from functools import partial
 
 from deepdiff import DeepDiff
 
-from dast.from_ast import strip, prettify
+from dast.from_ast import prettify
 
 _open_utf = partial(open, encoding="utf-8")
 
@@ -29,15 +29,16 @@ def main(then_path: str, now_path: str, verbose: bool = True):
         return None, None
     with _open_utf(then_path) as f_then:
         then_ast = ast.parse(f_then.read())
-        strip(then_ast)
         prettify(then_ast)
 
     with _open_utf(now_path) as f_now:
         now_ast = ast.parse(f_now.read())
-        strip(now_ast)
         prettify(now_ast)
 
-    diff = DeepDiff(then_ast, now_ast)
+    # This also includes end_lineno and end_col_offset
+    ignored_props = {"type_ignores", "type_comment", "col_offset", "lineno"}
+    callback = lambda _, path: any(path.endswith(prop) for prop in ignored_props)
+    diff = DeepDiff(then_ast, now_ast, exclude_obj_callback=callback)
     if diff and verbose:
         print(f"diff for file {now_path}")
         print(diff)

--- a/dast/from_ast.py
+++ b/dast/from_ast.py
@@ -15,20 +15,3 @@ def prettify(node: ast.AST):
         child.__class__ = PrettyAST
         child = cast(PrettyAST, child)
         child.node_type = node_type
-
-
-def strip(node: ast.AST):
-    """
-    Remove certain properties of an AST that
-    are not relevant for Python at runtime.
-    """
-    ignored_props = {"type_ignores", "type_coment", "col_offset", "end_col_offset", "lineno", "end_lineno"}
-    for key, value in vars(node).copy().items():
-        if key in ignored_props:
-            delattr(node, key)
-        else:
-            if isinstance(value, list):
-                for element in value:
-                    strip(element)
-            elif isinstance(value, ast.AST):
-                strip(value)


### PR DESCRIPTION
This will later allow us to reconstruct the code
from the AST so we can display it nicely, plus no
functions that mutate state silently.

Going to rewrite the diff display next so we can remove `prettify`